### PR TITLE
Add functionality for users to have non-embedding data columns as SVC model input

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "latent-viewer"
-version = "0.0.0"
+version = "0.0.1"
 description = "An interactive 3D viewer for inspecting image embeddings"
 readme = "README.md"
 authors = [{ name = "Leon Boschman", email = "leon.boschman@chalmers.se" }]

--- a/src/latent_viewer/viewer.py
+++ b/src/latent_viewer/viewer.py
@@ -682,6 +682,7 @@ def print_labels(labels):
     Input("svm-C-param", "value"),
     Input("svm-gamma-param", "value"),
     Input("metadata-column-names", "data"),
+    Input("metadata-column-selector", "value"),
     Input("embedding-column-names", "data"),
     prevent_initial_call="initial_duplicate",
 )
@@ -694,6 +695,7 @@ def query_model(
     svm_C: float,
     svm_gamma: float,
     metadata_columns: str,
+    selected_metadata_columns: list,
     embeddings_columns_str: str,
 ) -> tuple:
     """Query the model for the least confident data point.
@@ -707,6 +709,7 @@ def query_model(
         svm_C: SVC C hyperparameter
         svm_gamma: SVC gamma hyperparameter
         metadata_columns: json string containing list of metadata columns
+        selected_metadata_columns: list of metadata columns for model input
         embeddings_columns_str: json string containing list of embedding column names
 
     Returns:
@@ -732,7 +735,12 @@ def query_model(
     full_data = pd.read_json(StringIO(x_values_str))
     files = full_data[[filecolumn]].copy()
 
-    x_values = full_data[embeddings_columns]
+    x_columns = embeddings_columns
+    if selected_metadata_columns is not None:
+        x_columns += selected_metadata_columns
+
+    logger.debug(f"Using columns {x_columns}")
+    x_values = full_data[x_columns]
     y_values = pd.read_json(StringIO(y_labels_str))["label"].values
     clf.fit(x_values, y_values)
 

--- a/src/latent_viewer/viewer.py
+++ b/src/latent_viewer/viewer.py
@@ -235,6 +235,15 @@ app.layout = html.Div(
                                 "text-align": "center",
                             },
                         ),
+                        html.Div(
+                            [
+                                dcc.Checklist(
+                                    id="metadata-column-selector",
+                                    inline=True,
+                                )
+                            ],
+                            id="metadata-column-selector-container",
+                        ),
                     ],
                     id="label-prediction-container",
                     style={"inline": "true"},
@@ -877,3 +886,23 @@ def download_model(_n_clicks_button: int, svc_model: str):
     svm = active_learning_classifier.estimator
 
     return dcc.send_bytes(pickle.dumps(svm), filename=f"model_{dt_stamp}.pkl")
+
+
+@callback(
+    Output("metadata-column-selector", "options"),
+    Input("metadata-column-names", "data"),
+    prevent_initial_call=True,
+)
+def set_metadata_column_options(column_names_str: str):
+    """Populate the metadata column list with column names
+
+    Args:
+        column_names_str: column names list formatted as JSON string
+
+    Returns:
+        a mapping of {column_name : column_name}
+    """
+    column_names = json.loads(column_names_str)
+    column_names_dict = {name: name for name in column_names}
+    logger.debug(f"Column names dictionary: {column_names_dict}")
+    return column_names_dict

--- a/src/latent_viewer/viewer.py
+++ b/src/latent_viewer/viewer.py
@@ -268,7 +268,11 @@ app.layout = html.Div(
                                 dcc.Checklist(
                                     id="metadata-column-selector",
                                     inline=True,
-                                )
+                                    labelStyle={
+                                        "margin-right": "8pt",
+                                    },
+                                    inputStyle={"margin-right": "2pt"},
+                                ),
                             ],
                             id="metadata-column-selector-container",
                         ),


### PR DESCRIPTION
These columns have to be numeric in nature.
We do not automatically convert non-numerical columns to numerical data, because the conversion depends on the type of data.